### PR TITLE
Use the CloudWatch metric value as the k8s deployment scale value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -eux; \
   apk update; \
   apk upgrade; \
   apk add --update --no-cache tzdata ca-certificates curl jq bash less; \
-  apk add --update --no-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing aws-cli; \
+  apk add --update --no-cache --repository https://dl.alpinelinux.org/alpine/edge/testing aws-cli; \
   rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 # Add script

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ spec:
               value: "180"
             - name: KUBE_SCALE_UP_COOLDOWN # Optional, cooldown in seconds after scaling up
               value: "300"
+            - name: CW_SCALE_WITH_METRIC # Optional, use the metric value as the scale value
+              value: "false"
             - name: CW_SCALE_DOWN_VALUE # Required, cloudwatch metric value that will trigger scaling down
               value: "300"
             - name: CW_SCALE_UP_VALUE # Required, cloudwatch metric value that will trigger scaling up

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ spec:
               value: "300"
             - name: CW_SCALE_WITH_METRIC # Optional, use the metric value as the scale value
               value: "false"
-            - name: CW_SCALE_DOWN_VALUE # Required, cloudwatch metric value that will trigger scaling down
+            - name: CW_SCALE_DOWN_VALUE # Required if CW_SCALE_WITH_METRIC is false, cloudwatch metric value that will trigger scaling down
               value: "300"
-            - name: CW_SCALE_UP_VALUE # Required, cloudwatch metric value that will trigger scaling up
+            - name: CW_SCALE_UP_VALUE # Required if CW_SCALE_WITH_METRIC is false, cloudwatch metric value that will trigger scaling up
               value: "900"
             - name: CW_NAMESPACE # Required (see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)
               value: "AWS/SQS"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,10 @@ KUBE_SCALE_UP_COUNT="${KUBE_SCALE_UP_COUNT:-1}"
 KUBE_SCALE_DOWN_COOLDOWN="${KUBE_SCALE_DOWN_COOLDOWN:-180}"
 KUBE_SCALE_UP_COOLDOWN="${KUBE_SCALE_UP_COOLDOWN:-300}"
 CW_SCALE_WITH_METRIC="${CW_SCALE_WITH_METRIC:-false}"
-CW_SCALE_DOWN_VALUE="${CW_SCALE_DOWN_VALUE:?"Required: CW_SCALE_DOWN_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling down the replicas, such as '300'"}"
-CW_SCALE_UP_VALUE="${CW_SCALE_UP_VALUE:?"Required: CW_SCALE_UP_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling up the replicas, such as '900'"}"
+if [[ "${CW_SCALE_WITH_METRIC}" = false ]]; then
+    CW_SCALE_DOWN_VALUE="${CW_SCALE_DOWN_VALUE:?"Required: CW_SCALE_DOWN_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling down the replicas, such as '300'"}"
+    CW_SCALE_UP_VALUE="${CW_SCALE_UP_VALUE:?"Required: CW_SCALE_UP_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling up the replicas, such as '900'"}"
+fi
 CW_NAMESPACE="${CW_NAMESPACE:?"Required: CW_NAMESPACE must be set to the AWS CloudWatch Namespace, such as: 'AWS/SQS'"}"
 CW_METRIC_NAME="${CW_METRIC_NAME:?"Required: CW_METRIC_NAME must be set to the AWS CloudWatch MetricName, such as: 'ApproximateAgeOfOldestMessage'"}"
 CW_DIMENSIONS="${CW_DIMENSIONS:?"Required: CW_DIMENSIONS must be set to the AWS CloudWatch Dimensions, such as: 'Name=QueueName,Value=my_sqs_queue_name'"}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ KUBE_SCALE_DOWN_COUNT="${KUBE_SCALE_DOWN_COUNT:-1}"
 KUBE_SCALE_UP_COUNT="${KUBE_SCALE_UP_COUNT:-1}"
 KUBE_SCALE_DOWN_COOLDOWN="${KUBE_SCALE_DOWN_COOLDOWN:-180}"
 KUBE_SCALE_UP_COOLDOWN="${KUBE_SCALE_UP_COOLDOWN:-300}"
+CW_SCALE_WITH_METRIC="${CW_SCALE_WITH_METRIC:-false}"
 CW_SCALE_DOWN_VALUE="${CW_SCALE_DOWN_VALUE:?"Required: CW_SCALE_DOWN_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling down the replicas, such as '300'"}"
 CW_SCALE_UP_VALUE="${CW_SCALE_UP_VALUE:?"Required: CW_SCALE_UP_VALUE must be set to the AWS CloudWatch metric value that will trigger scaling up the replicas, such as '900'"}"
 CW_NAMESPACE="${CW_NAMESPACE:?"Required: CW_NAMESPACE must be set to the AWS CloudWatch Namespace, such as: 'AWS/SQS'"}"
@@ -88,31 +89,29 @@ do
         printf '%s\n' "$(date -u -I'seconds') AWS CloudWatch Value: ${CW_VALUE}"
     fi
 
-    # If the metric value is <= the scale-down value, and current replica count is > min replicas, and the last time we scaled up or down was at least the cooldown period ago
-    if [[ "${CW_VALUE}" -le "${CW_SCALE_DOWN_VALUE}"  &&  "${KUBE_CURRENT_REPLICAS}" -gt "${KUBE_MIN_REPLICAS}"  &&  "${KUBE_LAST_SCALING}" < $(date -u -I'seconds' -d @$(( $(date -u +%s) - ${KUBE_SCALE_DOWN_COOLDOWN} ))) ]]; then
-        NEW_REPLICAS=$(( ${KUBE_CURRENT_REPLICAS} - ${KUBE_SCALE_DOWN_COUNT} ))
-        NEW_REPLICAS=$(( ${NEW_REPLICAS} > ${KUBE_MIN_REPLICAS} ? ${NEW_REPLICAS} : ${KUBE_MIN_REPLICAS} ))
-        printf '%s\n' "$(date -u -I'seconds') Scaling down from ${KUBE_CURRENT_REPLICAS} to ${NEW_REPLICAS}"
-        PAYLOAD='[{"op":"replace","path":"/spec/replicas","value":'"${NEW_REPLICAS}"'}]'
-        SCALE_OUTPUT=$(curl -sS --cacert "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" -H "Authorization: Bearer ${KUBE_TOKEN}" -X PATCH -H 'Content-Type: application/json-patch+json' --data "${PAYLOAD}" "${KUBE_URL}")
-        if [[ "${?}" -ne 0 ]]; then
-            printf '%s\n' "$(date -u -I'seconds') Exiting: Unable to patch kubernetes deployment. Payload:${PAYLOAD} OUTPUT:${SCALE_OUTPUT}"
-            exit 1 # Kube will restart this pod
+    NEW_REPLICAS="${KUBE_CURRENT_REPLICAS}"
+
+    if [[ "${CW_SCALE_WITH_METRIC}" = true ]]; then
+        NEW_REPLICAS="${CW_VALUE}"
+    else
+        # If the metric value is <= the scale-down value, and current replica count is > min replicas, and the last time we scaled up or down was at least the cooldown period ago
+        if [[ "${CW_VALUE}" -le "${CW_SCALE_DOWN_VALUE}"  &&  "${KUBE_CURRENT_REPLICAS}" -gt "${KUBE_MIN_REPLICAS}"  &&  "${KUBE_LAST_SCALING}" < $(date -u -I'seconds' -d @$(( $(date -u +%s) - ${KUBE_SCALE_DOWN_COOLDOWN} ))) ]]; then
+            NEW_REPLICAS=$(( ${KUBE_CURRENT_REPLICAS} - ${KUBE_SCALE_DOWN_COUNT} ))
         fi
-        # Confirm response says correct number of replicas, instead of an error message
-        SCALE_REPLICAS=$(printf '%s' "${SCALE_OUTPUT}" | jq '.spec.replicas')
-        if [[ "${SCALE_REPLICAS}" -ne "${NEW_REPLICAS}" ]]; then
-            printf '%s\n' "$(date -u -I'seconds') Exiting: Unable to patch kubernetes deployment. Payload:${PAYLOAD} OUTPUT:${SCALE_OUTPUT}"
-            exit 1 # Kube will restart this pod
+
+        # If the metric value is >= the scale-up value, and current replica count is < max replicas, and the last time we scaled up or down was at least the cooldown period ago
+        if [[ "${CW_VALUE}" -ge "${CW_SCALE_UP_VALUE}"  &&  "${KUBE_CURRENT_REPLICAS}" -lt "${KUBE_MAX_REPLICAS}"  &&  "${KUBE_LAST_SCALING}" < $(date -u -I'seconds' -d @$(( $(date -u +%s) - ${KUBE_SCALE_UP_COOLDOWN} ))) ]]; then
+            NEW_REPLICAS=$(( ${KUBE_CURRENT_REPLICAS} + ${KUBE_SCALE_UP_COUNT} ))
         fi
-        KUBE_LAST_SCALING=$(date -u -I'seconds')
     fi
 
-    # If the metric value is >= the scale-up value, and current replica count is < max replicas, and the last time we scaled up or down was at least the cooldown period ago
-    if [[ "${CW_VALUE}" -ge "${CW_SCALE_UP_VALUE}"  &&  "${KUBE_CURRENT_REPLICAS}" -lt "${KUBE_MAX_REPLICAS}"  &&  "${KUBE_LAST_SCALING}" < $(date -u -I'seconds' -d @$(( $(date -u +%s) - ${KUBE_SCALE_UP_COOLDOWN} ))) ]]; then
-        NEW_REPLICAS=$(( ${KUBE_CURRENT_REPLICAS} + ${KUBE_SCALE_UP_COUNT} ))
-        NEW_REPLICAS=$(( ${NEW_REPLICAS} < ${KUBE_MAX_REPLICAS} ? ${NEW_REPLICAS} : ${KUBE_MAX_REPLICAS} ))
-        printf '%s\n' "$(date -u -I'seconds') Scaling up from ${KUBE_CURRENT_REPLICAS} to ${NEW_REPLICAS}"
+    # Clamp new replicas to the min and max configured values
+    NEW_REPLICAS=$(( ${NEW_REPLICAS} > ${KUBE_MIN_REPLICAS} ? ${NEW_REPLICAS} : ${KUBE_MIN_REPLICAS} ))
+    NEW_REPLICAS=$(( ${NEW_REPLICAS} < ${KUBE_MAX_REPLICAS} ? ${NEW_REPLICAS} : ${KUBE_MAX_REPLICAS} ))
+
+    # If the scale has changed
+    if [[ "${NEW_REPLICAS}" -ne "${KUBE_CURRENT_REPLICAS}"]]; then
+        printf '%s\n' "$(date -u -I'seconds') Scaling from ${KUBE_CURRENT_REPLICAS} to ${NEW_REPLICAS}"
         PAYLOAD='[{"op":"replace","path":"/spec/replicas","value":'"${NEW_REPLICAS}"'}]'
         SCALE_OUTPUT=$(curl -sS --cacert "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" -H "Authorization: Bearer ${KUBE_TOKEN}" -X PATCH -H 'Content-Type: application/json-patch+json' --data "${PAYLOAD}" "${KUBE_URL}")
         if [[ "${?}" -ne 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,7 +110,7 @@ do
     NEW_REPLICAS=$(( ${NEW_REPLICAS} < ${KUBE_MAX_REPLICAS} ? ${NEW_REPLICAS} : ${KUBE_MAX_REPLICAS} ))
 
     # If the scale has changed
-    if [[ "${NEW_REPLICAS}" -ne "${KUBE_CURRENT_REPLICAS}"]]; then
+    if [[ "${NEW_REPLICAS}" -ne "${KUBE_CURRENT_REPLICAS}" ]]; then
         printf '%s\n' "$(date -u -I'seconds') Scaling from ${KUBE_CURRENT_REPLICAS} to ${NEW_REPLICAS}"
         PAYLOAD='[{"op":"replace","path":"/spec/replicas","value":'"${NEW_REPLICAS}"'}]'
         SCALE_OUTPUT=$(curl -sS --cacert "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" -H "Authorization: Bearer ${KUBE_TOKEN}" -X PATCH -H 'Content-Type: application/json-patch+json' --data "${PAYLOAD}" "${KUBE_URL}")

--- a/example_autoscaler_kube.yaml
+++ b/example_autoscaler_kube.yaml
@@ -32,6 +32,8 @@ spec:
               value: "180"
             - name: KUBE_SCALE_UP_COOLDOWN # Optional, cooldown in seconds after scaling up
               value: "300"
+            - name: CW_SCALE_WITH_METRIC # Optional, use the metric value as the scale value
+              value: "false"
             - name: CW_SCALE_DOWN_VALUE # Required, cloudwatch metric value that will trigger scaling down
               value: "300"
             - name: CW_SCALE_UP_VALUE # Required, cloudwatch metric value that will trigger scaling up

--- a/example_autoscaler_kube.yaml
+++ b/example_autoscaler_kube.yaml
@@ -34,9 +34,9 @@ spec:
               value: "300"
             - name: CW_SCALE_WITH_METRIC # Optional, use the metric value as the scale value
               value: "false"
-            - name: CW_SCALE_DOWN_VALUE # Required, cloudwatch metric value that will trigger scaling down
+            - name: CW_SCALE_DOWN_VALUE # Required if CW_SCALE_WITH_METRIC is false, cloudwatch metric value that will trigger scaling down
               value: "300"
-            - name: CW_SCALE_UP_VALUE # Required, cloudwatch metric value that will trigger scaling up
+            - name: CW_SCALE_UP_VALUE # Required if CW_SCALE_WITH_METRIC is false, cloudwatch metric value that will trigger scaling up
               value: "900"
             - name: CW_NAMESPACE # Required (see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)
               value: "AWS/SQS"


### PR DESCRIPTION
Instead of using a metric and threshold to decide to scale up/down by a certain amount, this allows you to use a metric value directly to drive the scale of a k8s deployment.